### PR TITLE
Upgrade the sysdig provider

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1389,7 +1389,7 @@ submodules:
       - name: "sysdig"
         namespace: ""
         source: "sysdiglabs/sysdig"
-        version: "0.5.10"
+        version: "0.5.37"
     inputs:
       - name: "provision"
         type : bool

--- a/modules/monitoring-sysdig/versions.tf
+++ b/modules/monitoring-sysdig/versions.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     sysdig = {
       source = "sysdiglabs/sysdig"
-      version = "0.5.10"
+      version = "0.5.37"
     }
 
     ibm = {
@@ -29,7 +29,7 @@ terraform {
   required_providers {
     sysdig = {
       source  = "sysdiglabs/sysdig"
-      version = "0.5.10"
+      version = "0.5.37"
     }
 
     ibm = {


### PR DESCRIPTION
The sysdig provider `0.5.10` is not compiled for the `darwin_arm64` architecture.
This has been fixed in version `0.5.12` of the sysdig provider.
This PR upgrades the sysdig provider to the latest version so that the `terraform-ibm-observability` module can be used on `darwin_arm64`, including recent M1 CPUs from Apple.